### PR TITLE
fix target path to extract archive

### DIFF
--- a/update-github-latest
+++ b/update-github-latest
@@ -6,5 +6,5 @@ VERSION=$(github-latest acim/github-latest)
 FILENAME=github-latest-v${VERSION}-linux-amd64.tar.gz
 URL=https://github.com/acim/github-latest/releases/download/v${VERSION}/${FILENAME}
 
-curl -L  ${URL} | tar -zxC /usr/local
+curl -L  ${URL} | tar -zxC /usr/local/bin
 chown root:root /usr/local/bin/github-latest


### PR DESCRIPTION
The update process fails because _chown_ tries to access a non-existing directory. Changing the path where _tar_ extracts the archive solves this issue.